### PR TITLE
Fixes command line option arguments for service script.

### DIFF
--- a/templates/lib/systemd/system/mailcatcher.j2
+++ b/templates/lib/systemd/system/mailcatcher.j2
@@ -14,7 +14,7 @@ ExecStartPre=/usr/bin/install -d \
   -m 0755 \
   {{ mailcatcher_log_file | dirname }}
 ExecStart=/bin/sh -c \
-  '{{ mailcatcher_daemon }} --foreground{% for key, value in mailcatcher_options.iteritems() %} -{{ key }} {{ value }}{% endfor %} >> {{ mailcatcher_log_file }} 2>&1'
+  '{{ mailcatcher_daemon }} --foreground{% for key, value in mailcatcher_options.iteritems() %} --{{ key }} {{ value }}{% endfor %} >> {{ mailcatcher_log_file }} 2>&1'
 
 PIDFile={{ mailcatcher_pid_file }}
 Restart=always


### PR DESCRIPTION
I had issues starting the service with 'service mailcatcher start' whilst using the ip option in the mailcatcher_options. It seemed the command line argument was being passed with one hypen instead of two.